### PR TITLE
Hw bugfix resolve

### DIFF
--- a/dev-backend/static/images/Warning.svg
+++ b/dev-backend/static/images/Warning.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 50 50">
+        <path d="M0 43h50l-25-43z" fill="#F0E020" stroke-width="1" stroke="#C0B010"/>
+        <rect x="23" y="15" height="15" rx="2" width="4" fill="rgba(0,0,0,0.6)" />
+        <circle cx="25" cy="36" r="2" fill="rgba(0,0,0,0.6)"/>
+        <path d="M520.5 78.1z"/>
+</svg>

--- a/dev-backend/testData/templates.json
+++ b/dev-backend/testData/templates.json
@@ -195,20 +195,21 @@
           }
         },
         {
+          "key": "teamname",
+          "type": "caption",
+          "x": 50, "y": 67, "w": 80, "h": 18,
+          "text": "Team: {{jira:team}}",
+          "style": {"$": "LABEL_SMALL_STYLE"}
+        },
+        {
           "key": "status",
-          "type": "textfield",
+          "type": "caption",
           "x": 130,
           "y": 67,
           "w": 90,
           "h": 20,
-          "attribute": "jira:status",
-          "style": {
-            "font-size": "12px",
-            "font-weight": "normal",
-            "color": {
-              "$": "TEXT_COLOR"
-            }
-          }
+          "text": "Status: {{jira:status}}",
+          "style": {"$": "LABEL_SMALL_STYLE"}
         },
         {
           "key": "link",
@@ -219,7 +220,7 @@
           "h": 12,
           "urlAttribute": "core:url",
           "style": {
-            "font-size": "12px",
+            "font-size": "8px",
             "font-weight": "normal"
           },
           "text": "Jira Link"
@@ -273,7 +274,7 @@
         "cornerRadius": "6px"
       },
       "clickable": true,
-      "preprocessing": [{"method":  "aggregate", "input": "jira:ticket", "results": {"storyPointSum":  {"attribute":  "jira:storypoints", "calculate": "sum"}}}],
+      "preprocessing": [{"method":  "aggregate", "input": "jira:ticket", "results": {"storyPointSum":  {"attribute":  "jira:storypoints", "calculate": "sum"}, "storyPoints": {"attribute":  "jira:storypoints", "calculate": "sum"}}}],
       "elements": [
         {
           "key": "heading",
@@ -283,10 +284,17 @@
           "style": {"$": "LABEL_STYLE"}
         },
         {
+          "key": "warning",
+          "type": "image",
+          "condition": {"storyPoints": ">120"},
+          "x": 160, "y": 10, "w": 30, "h": 30,
+          "source": "images/Warning.svg"
+        },
+        {
           "key": "storycaption",
           "type": "caption",
-          "x": 12, "y": 48, "w": 80, "h": 18,
-          "text": "Stories",
+          "x": 12, "y": 48, "w": 140, "h": 18,
+          "text": "Stories ({{storyPoints}} story points)",
           "style": {"$": "LABEL_SMALL_STYLE"}
         },
         {
@@ -315,8 +323,8 @@
           "x": 250,
           "y": 30,
           "diameter": 130,
-          "dimensions": ["dcc:bugs", "dcc:speed", "dcc:downstream"],
-          "maxValues": {"dcc:bugs": 140, "dcc:speed": 38, "dcc:downstream": 100},
+          "dimensions": ["dcc:bugs", "storyPoints", "dcc:downstream"],
+          "maxValues": {"dcc:bugs": 140, "storyPoints": 180, "dcc:downstream": 100},
           "colorStops": [{"percent": "0", "color":  "#548546"}, {"percent": "25", "color":  "#7ea550"}, {"percent":  "35", "color":  "#a3b630"}, {"percent":  "50", "color":  "#cfc726"},{"percent":  "60", "color":  "#cfc726"}, {
             "percent": "90", "color": "#b65b56"} ],
           "labels": ["Bugs", "Load", "Downstream"],

--- a/dev-backend/testData/templates.json
+++ b/dev-backend/testData/templates.json
@@ -234,7 +234,7 @@
       "detailTemplate": "jira:ticket",
       "aggregate": false,
       "size": { "w": 220, "h": 120},
-      "background": { "type": "rect", "w": 220, "h": 120, "cornerRadius": "6px"},
+      "background": { "type": "rect", "w": 220, "h": 120, "cornerRadius": 6},
       "clickable": true,
       "colorcoding": {
         "type": "selection",
@@ -271,7 +271,7 @@
         "borderColor": "#E8E8E8",
         "w": 400,
         "h": 150,
-        "cornerRadius": "6px"
+        "cornerRadius": 6
       },
       "clickable": true,
       "preprocessing": [{"method":  "aggregate", "input": "jira:ticket", "results": {"storyPointSum":  {"attribute":  "jira:storypoints", "calculate": "sum"}, "storyPoints": {"attribute":  "jira:storypoints", "calculate": "sum"}}}],
@@ -342,7 +342,7 @@
         "w": 420,
         "h": 500,
         "color": {"$":  "AREA_BACKGROUND_COLOR"},
-        "cornerRadius": "6px"
+        "cornerRadius": 6
       },
       "clickable": true,
       "options":  {
@@ -390,7 +390,7 @@
         "w": 420,
         "h": 900,
         "color": {"$":  "AREA_BACKGROUND_COLOR"},
-        "cornerRadius": "6px"
+        "cornerRadius": 6
       },
       "clickable": true,
       "elements": [
@@ -459,7 +459,7 @@
         "w": 700,
         "h": 500,
         "color": {"$": "AREA_BACKGROUND_COLOR"},
-        "cornerRadius": "6px"
+        "cornerRadius": 6
       },
       "options":  {
         "view": {
@@ -502,7 +502,7 @@
         "type": "rect",
         "w": 600,
         "h": 600,
-        "cornerRadius": "6px",
+        "cornerRadius": 6,
         "color":  {"$":  "AREA_BACKGROUND_COLOR"},
         "x": 0,
         "y": 0
@@ -700,7 +700,7 @@
         "type": "rect",
         "w": 300,
         "h": 500,
-        "cornerRadius": "6px",
+        "cornerRadius": 6,
         "color": {"$": "AREA_BACKGROUND_COLOR"},
         "x": 0,
         "y": 0
@@ -847,7 +847,7 @@
       "appliesTo": "jira:ticket",
       "background": {
         "type": "rect", "w": 720, "h": 500,
-        "cornerRadius": "6px",
+        "cornerRadius": 6,
         "color": {"$": "AREA_BACKGROUND_COLOR"}
       },
       "options":  {

--- a/documentation/Card_design.md
+++ b/documentation/Card_design.md
@@ -36,7 +36,7 @@ Here is an example from the development server:
       "appliesTo": "jira:ticket",
       "aggregate": false,
       "size": { "w": 220, "h": 120},
-      "background": { "type": "rect", "w": 220, "h": 120, "cornerRadius": "6px"},
+      "background": { "type": "rect", "w": 220, "h": 120, "cornerRadius": 6},
       "clickable": true,
       "colorcoding": {
         "type": "selection",
@@ -65,9 +65,16 @@ Here is an example from the development server:
 ### All elements:
 * `key` an identifier that must be unique in the scope of the parent element
 * `x`, `y`, `w`, `h` x and y position, width and height of the element (in the parent element's coordinate system)
+* `condition`: An optional condition that prevents the element from being rendered if the condition fails. 
+The form of the condition is `{"<attribute>": "<comparator><comparand>"}`. For available comparators see inputSelector
+  in [chart](#chart)
 
 ### textfield
-* `attribute` the attribute of the card node to be displayed
+* `attribute` the attribute of the card node to be displayed. The attribute can be a direct attribute of the current
+  node of a path expression using `/` as separators to traverse to an attribute of an associated element. For example,
+  you could use an expression `jira:team/dcc:speed` to include the speed (story points per sprint) of the associated team
+  in a ticket. If the evaluation of the path results in a graph node instead of a primitive (e.g. `jira:team`), the 
+  node's display name will be used as attribute value. If no name attribute is present, the uri of the node is used.
 * `style` an object that corresponds to a css style, supporting these attributes
   * `color`
   * `background-color`
@@ -83,7 +90,8 @@ Here is an example from the development server:
 
 ### caption
 Caption is the same as a text field, but instead of `attribute`, it has a `text` attribute, which is a text literal
-which can embed node attribute values with handlebar syntax, e.g. `Node {{core:name}}`
+which can embed node attribute values with handlebar syntax, e.g. `Node {{core:name}}`. As in [textfield](#textfield), 
+a path expression can be used inside the handlebars.
 
 ### box
 The box is the same as a text field without any text. It's appearance is controlled by the style attributes
@@ -104,6 +112,7 @@ The box is the same as a text field without any text. It's appearance is control
   * `inputSelector` `{"<attribute>": "<comparator><comparand>"}`
     where `<comparator>` is one of `=`, `!=`, `<`, `<=`, `>`,`>=`, `empty`, `exists`, `contains`, `!contains`, `->`
     The input selector filters the data from `source` before it is fed into the chart
+    Comparands can use the same handlebar notation as [caption](#caption) to use attributes associated to the current node.
   * `overlay` a set of contextual nodes (calculated in preprocess methods) that amend the nodes fed into the chart by
     calculated attributes or associations - arcane
 

--- a/src/App.js
+++ b/src/App.js
@@ -89,7 +89,7 @@ class App extends Component {
               dataLoaded: true
             });
             const startTemplate = getConfig('startTemplate');
-            this.setFocusCard(this.createFocusCard(startData, TemplateRegistry.getTemplate(startTemplate), {}));
+            this.setFocusCard(this.createFocusCard(startData, TemplateRegistry.getTemplate(startTemplate), null), startData);
           }
         });
     this.handleNodeClick = this.handleNodeClick.bind(this);
@@ -449,8 +449,8 @@ class App extends Component {
   }
 
 
-  setFocusCard(focusCard) {
-    this.transitionToState(this.createStateForFocus(focusCard, null));
+  setFocusCard(focusCard, data) {
+    this.transitionToState(this.createStateForFocus(focusCard, data));
   }
 
 
@@ -529,6 +529,10 @@ class App extends Component {
   handleViewSelect(viewId) {
     const {focusData, currentFilters, mainWidth, focusHeight} = this.state;
     const template = TemplateRegistry.getTemplate(viewId);
+
+    if (template.aggregate && !focusData[TYPE_NODES]) {
+      throw new Error(`Template ${template.id} is marked as aggregate, but applied to non-aggregate data ${focusData.getUniqueKey()}`);
+    }
 
     const data = template.aggregate ?  createPreprocessedCardNode(applyFilters(Object.values(currentFilters),
         focusData[TYPE_NODES].map(node => (node.originalNode || node))), {}, template, focusData[TYPE_NAME]): this.state.focusCard.data;

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ import {Div_} from '@symb/Div';
 import {Card_} from "@/components/Card";
 import {Sidebar_} from "@/components/Sidebar";
 import GraphNode from "@/graph/GraphNode";
-import {HOVER_MENU_DELAY, MARGIN, SIDEBAR_MAX, SIDEBAR_PERCENT} from "@/Config";
+import {getConfig, HOVER_MENU_DELAY, MARGIN, SIDEBAR_MAX, SIDEBAR_PERCENT} from "@/Config";
 import {fit, isDataEqual, relSpatial} from "@symb/util";
 import {breadCrumbHoverIcon, createPreprocessedCardNode, hoverCardMenu} from "@/components/Generators";
 import {BreadcrumbLane_} from "@/components/BreadcrumbLane";
@@ -26,6 +26,8 @@ const SIDEBAR = 'sidebar';
 const FOCUS = 'focus';
 const HOVER_MENU = 'hover-menu';
 const TOOL_HEIGHT = 10;
+const BREADCRUMB_LANE_HEIGHT = 120;
+const SCROLLBAR_HEIGHT = 30;
 
 class App extends Component {
 
@@ -86,8 +88,8 @@ class App extends Component {
               focusData: startData,
               dataLoaded: true
             });
-            const { startTemplate } = Cache.getConfig();
-                this.setFocusCard(this.createFocusCard(startData, TemplateRegistry.getTemplate(startTemplate), {}));
+            const startTemplate = getConfig('startTemplate');
+            this.setFocusCard(this.createFocusCard(startData, TemplateRegistry.getTemplate(startTemplate), {}));
           }
         });
     this.handleNodeClick = this.handleNodeClick.bind(this);
@@ -310,7 +312,7 @@ class App extends Component {
     }
 
     const breadcrumbNativeSize = sourceCard.template.getSize();
-    const newBreadcrumbScale =  (breadCrumbHeight - 24) / breadcrumbNativeSize.height;
+    const newBreadcrumbScale =  (breadCrumbHeight - SCROLLBAR_HEIGHT) / breadcrumbNativeSize.height;
     const newBreadcrumbSpatial = {x: nextChildPos, y: 7, scale: newBreadcrumbScale};
     const newBreadCrumbCard = {...sourceCard, ...breadCrumbChanges, spatial: newBreadcrumbSpatial};
     const newNextChildPos = nextChildPos + newBreadcrumbScale * breadcrumbNativeSize.width + MARGIN;
@@ -379,6 +381,7 @@ class App extends Component {
     const { breadCrumbCards } = this.state;
     const card = breadCrumbCards.find(card =>
         card.key === key);
+    if (!card) return;
     const { template } = card;
     const top = card.spatial.y;
     const scaledWidth = template.getSize().width * card.spatial.scale;
@@ -473,7 +476,7 @@ class App extends Component {
 
 
   updatedFocusCard(focusCard, focusData, filters) {
-    if (!focusData.getTypeUri() === TYPE_AGGREGATOR) {
+    if (focusData.getTypeUri() !== TYPE_AGGREGATOR) {
       throw new Error('UpdateFocusCard called for non-aggregate card');
     }
     const data = createPreprocessedCardNode(applyFilters(Object.values(filters), focusData[TYPE_NODES]),
@@ -585,7 +588,7 @@ class App extends Component {
   recalcLayout({toolControls, windowWidth, windowHeight, focusCard, hoverCard}) {
     const sideBarWidth = Math.min(Math.min(SIDEBAR_PERCENT * windowWidth, SIDEBAR_MAX), 4 * windowHeight);
 
-    const breadCrumbHeight = 120;
+    const breadCrumbHeight = BREADCRUMB_LANE_HEIGHT;
     const toolControlList = Object.values(toolControls);
     // noinspection JSCheckFunctionSignatures
     const toolbarHeight = toolControlList.reduce((result, control) => Math.max(result, (control.size.height || 0)), 0) + 2 * MARGIN;

--- a/src/CheckedObject.js
+++ b/src/CheckedObject.js
@@ -9,10 +9,14 @@ export default class CheckedObject {
 
   constructor(descriptor) {
     if (DEBUG_MODE) {
+      let error = false;
       if (!this.constructor.propertyTypes) {
         throw new Error(`Missing static member propertyTypes in CheckedObject subclass ${this.constructor.name}`);
       }
-      P.checkPropTypes(this.constructor.propertyTypes, descriptor, 'parameter', 'Type constructor');
+      P.checkPropTypes(this.constructor.propertyTypes, descriptor, 'parameter', 'Type',()=>{error = true;});
+      if (error) {
+        console.log(`... in ${JSON.stringify(descriptor)}`);
+      }
     }
     Object.keys(this.constructor.propertyTypes).forEach(prop => this[prop] = descriptor[prop]);
   }

--- a/src/Config.js
+++ b/src/Config.js
@@ -1,3 +1,6 @@
+import { pick } from 'lodash';
+import {TYPE_NAME} from "@/graph/Cache";
+
 export const DEBUG_MODE = true;
 export const OFFLINE_MODE = false;
 
@@ -28,9 +31,6 @@ export const SIDEBAR_BACK_COLOR = '#EEEEEA';
 
 export const SIDEBAR_BACK_COLOR2 = '#bcbdb7';
 
-
-
-
 export const QCC_BLUE_1 = 'rgb(93,113,123)';
 export const QCC_BLUE_2 = 'rgb(60,78,86)';
 export const QCC_BLUE_3 = 'rgb(52,67,74)';
@@ -43,4 +43,18 @@ export const QCC_GRAY_5 = '#696966';
 
 export const QCC_GRAY_SIDEBAR = `rgb(233,234,228)`;
 
+const configuration = {
+  displayNameAttribute : TYPE_NAME
+};
 
+export const setConfig = function setConfig(config) {
+  Object.assign(configuration, config);
+}
+
+export const getConfigs = function getConfigs(parameterList) {
+  return pick(configuration, parameterList);
+}
+
+export const getConfig = function (parameterName) {
+  return configuration[parameterName];
+}

--- a/src/Data.js
+++ b/src/Data.js
@@ -1,10 +1,11 @@
 import {omit} from "lodash";
 import Cache from "@/graph/Cache";
 import TemplateRegistry from "@/templates/TemplateRegistry";
-import {OFFLINE_MODE} from "@/Config";
+import {getConfigs, OFFLINE_MODE, setConfig} from "@/Config";
 import {
   getCardDescriptorsOffline,
-  getClientConfigOffline, getDataOffline,
+  getClientConfigOffline,
+  getDataOffline,
   getDictionaryOffline,
   getToolDescriptorsOffline
 } from "@/OfflineData/pseudobackend";
@@ -106,7 +107,7 @@ export const getClientConfigFromDB = function (onError) {
   return fetch('/api/config')
       .then(handleResponse)
       .then(result => {
-        Cache.setConfig(result.data)})
+        setConfig(result.data)})
       .catch(error => {
         console.log(error.stack);
         onError(error);
@@ -157,13 +158,13 @@ export const getData = function (onError) {
 }
 
 export const getDataFromDB = function(onError) {
-  const config = Cache.getConfig();
+
+  const {getTables, getGraph} = getConfigs(['getTables', 'getGraph']);
 
   /**
    * @type {Promise[]}
    */
   const result = [];
-  const {getTables, getGraph} = config;
   if (getGraph) {
     result.push(
         fetch(`/api/graph`, {})

--- a/src/OfflineData/pseudobackend.js
+++ b/src/OfflineData/pseudobackend.js
@@ -3,6 +3,7 @@ import {data, graph} from '@/OfflineData/data';
 import Cache from "@/graph/Cache";
 import TemplateRegistry from "@/templates/TemplateRegistry";
 import {preprocess} from "@/Data";
+import {getConfigs, setConfig} from "@/Config";
 
 export const OFFLINE_DATA = { config, dictionary, templates, tools, data, graph };
 
@@ -19,7 +20,7 @@ export const getDictionaryOffline = function (onError) {
 export const getClientConfigOffline = function () {
   return pseudoFetch(OFFLINE_DATA.config)
       .then(data => {
-        Cache.setConfig(data)});
+        setConfig(data)});
 }
 
 export const getCardDescriptorsOffline = function (onError) {
@@ -54,13 +55,12 @@ export const getToolDescriptorsOffline = function (onError) {
 
 
 export const getDataOffline = function(onError) {
-  const config = Cache.getConfig();
 
   /**
    * @type {Promise[]}
    */
   const result = [];
-  const { getTables, getGraph } = config;
+  const { getTables, getGraph } = getConfigs('getTables', 'getGraph');
   if (getGraph) {
     result.push(
        pseudoFetch(OFFLINE_DATA.graph)

--- a/src/components/BreadcrumbLane.css
+++ b/src/components/BreadcrumbLane.css
@@ -6,15 +6,17 @@
     border-top: solid 1px #536e73;
     box-sizing: border-box;
     user-select: none;
+    /*noinspection CssUnknownProperty*/
+    scrollbar-color: #69878c #5e7b80;
 }
 .lane::-webkit-scrollbar {
-    height: 12px;
+    height: 14px;
 }
 .lane::-webkit-scrollbar-thumb {
     background-color: #69878c;
     border-top: solid 1px #5c7980;
     height: 100%;
-    border-radius: 6px;
+    border-radius: 7px;
     cursor: grab;
     transition: background-color 0.4s;
     border-bottom: solid 1px #536d73;

--- a/src/components/Generators.js
+++ b/src/components/Generators.js
@@ -60,7 +60,7 @@ export const Background = function Background(props, color) {
   switch (type) {
     case BACKGROUND_RECT:
       return Div_({key: KEY_BACKGROUND, className, spatial,
-        style:{backgroundColor: color, width: w, height: h, borderRadius: cornerRadius, border: borderColor && `solid 1px ${borderColor}`}})._Div;
+        style:{backgroundColor: color, width: w, height: h, borderRadius: `${cornerRadius}px`, border: borderColor && `solid 1px ${borderColor}`}})._Div;
     case BACKGROUND_IMAGE:
       return Image_({key: KEY_BACKGROUND, className, spatial, source, width: w, height: h, color, cornerRadius})._Image;
     default:

--- a/src/components/Generators.js
+++ b/src/components/Generators.js
@@ -20,6 +20,19 @@ import {preprocess} from "@/graph/Preprocessors";
 import hoverMenuCss from './HoverCardMenu.css';
 import {Link_} from "@/components/Link";
 
+export const STYLE_ATTRIBUTES = [
+ 'color',
+ 'background-color',
+ 'border-radius',
+ 'font-weight',
+ 'font-size',
+ 'padding',
+ 'z-index',
+ 'font-family',
+ 'h-align',
+ 'v-align'
+]
+
 const PADDING = 0.2;
 const KEY_BACKGROUND = 'background';
 

--- a/src/graph/Cache.js
+++ b/src/graph/Cache.js
@@ -192,7 +192,7 @@ class Cache {
   validateNodes() {
     Object.values(this.lookUpGlobal).forEach(node => {
       if (!node.type) {
-        console.error(`node ${node.uri} has no type`);
+        console.warn(`node ${node.uri} has no type`);
       }
     });
   }

--- a/src/graph/Cache.js
+++ b/src/graph/Cache.js
@@ -41,17 +41,6 @@ class Cache {
     this.createType({uri: TYPE_NODE_COUNT, name: 'node count', dataType: DATATYPE_INTEGER, isAssociation: false});
   };
 
-  setConfig(config) {
-    this.config = config;
-    if (!this.config.displayNameAttribute){
-      this.config.displayNameAttribute = 'core:name';
-    }
-  }
-
-  getConfig() {
-    return this.config;
-  }
-
   createUri() {
     return `core:surrogate${this.idCount++}`;
   }
@@ -260,25 +249,10 @@ export const resolve = function (node, path) {
  * @return {String | Number} resolved attribute or display name of resolved node
  */
 export const resolveAttribute = function (node, path) {
-  let result;
-
-  if (Array.isArray(path) || path.includes('/')) {
-    const segments = Array.isArray(path) ? path : path.split('/');
-    let current = node;
-    for (let segIdx = 0; segIdx < segments.length; segIdx++) {
-      current = current.constructor === GraphNode ? current.get(segments[segIdx]) : current[segments[segIdx]];
-      // simplistic disambiguation - if multiple, select first
-      if (segIdx < segments.length - 1 && Array.isArray(current)) {
-        current = current[0];
-      }
-    }
-    result = current;
-  } else {
-    result = node.constructor === GraphNode ? node.get(path) : node[path];
-  }
+  const result = resolveProperty(node, path);
 
   return (result && result.constructor === GraphNode) ?
-      result.displayName() :
+      result.getDisplayName() :
       result;
 };
 
@@ -286,7 +260,7 @@ export const resolveAttribute = function (node, path) {
  *
  * @param {GraphNode} node
  * @param {String[] | String} path
- * @return {String | Number} resolved attribute or resolved node
+ * @return {String | Number | Object} resolved attribute or resolved node
  */
 export const resolveProperty = function (node, path) {
   let result;
@@ -295,6 +269,7 @@ export const resolveProperty = function (node, path) {
     const segments = Array.isArray(path) ? path : path.split('/');
     let current = node;
     for (let segIdx = 0; segIdx < segments.length; segIdx++) {
+      if (!current) break;
       current = current.constructor === GraphNode ? current.get(segments[segIdx]) : current[segments[segIdx]];
       // simplistic disambiguation - if multiple, select first
       if (segIdx < segments.length - 1 && Array.isArray(current)) {

--- a/src/graph/Filter.js
+++ b/src/graph/Filter.js
@@ -8,7 +8,7 @@ export const restAfter = function(string, prefix) {
     if (string.charAt(i) !== prefix.charAt(i)) return null;
   }
   const rest = string.substr(prefix.length).trim();
-  if (!isNaN(rest)) {
+  if (rest!=='' && !isNaN(rest)) {
     return Number(rest)
   } else return rest;
 };
@@ -27,12 +27,12 @@ export const COMPARISON_GREATER = (testValue, value) => value > testValue;
 export const COMPARISON_EXISTS = (testValue, value) => value != null;
 export const COMPARISON_EMPTY = (testValue, value) => value == null;
 export const COMPARISON_HAS_ASSOCIATED =  (testValue, value) => {
-    if (typeof testValue === 'string') {
-      if (!value) return false;
-      return Array.isArray(value) ? value.find(node => node.uri === testValue) : (value.constructor === GraphNode && value.uri === testValue);
-    } else if (typeof testValue === 'object' && testValue.constructor === GraphNode) {
-      return Array.isArray(value) ? value.includes(testValue) : (value === testValue);
-    }
+  if (typeof testValue === 'string') {
+    if (!value) return false;
+    return Array.isArray(value) ? value.find(node => node.uri === testValue) : (value.constructor === GraphNode && value.uri === testValue);
+  } else if (typeof testValue === 'object' && testValue.constructor === GraphNode) {
+    return Array.isArray(value) ? value.includes(testValue) : (value === testValue);
+  }
 }
 
 const comparisons = [
@@ -83,7 +83,7 @@ export default class Filter {
   constructor(attribute, matchFunction, comparand) {
     this.attribute = attribute;
     this.matchFunction = matchFunction;
-    this.isNumeric = !isNaN(comparand) && attribute !== TYPE_TYPE;
+    this.isNumeric = comparand !== '' && !isNaN(comparand) && attribute !== TYPE_TYPE;
     this.comparand = this.isNumeric ? Number(comparand): comparand;
     this.dynamicComparand = (typeof comparand === 'string' && comparand.includes('{{'));
     this.matches = this.matches.bind(this);

--- a/src/graph/GraphNode.js
+++ b/src/graph/GraphNode.js
@@ -4,8 +4,9 @@ import Cache, {
   DATATYPE_INTEGER,
   DATATYPE_STRING,
   TYPE_CONTEXTUAL_NODE,
-  TYPE_NAME, TYPE_THING
+  TYPE_THING
 } from './Cache';
+import {getConfig} from "@/Config";
 
 // noinspection JSUnusedGlobalSymbols
 export default class GraphNode {
@@ -61,7 +62,7 @@ export default class GraphNode {
   };
 
   getDisplayName() {
-    return this[Cache.getConfig().displayNameAttribute] || this.uri;
+    return this[getConfig('displayNameAttribute')] || this.uri;
   }
 
   // noinspection JSUnusedGlobalSymbols
@@ -117,11 +118,6 @@ export default class GraphNode {
     }
     return result;
   }
-
-  displayName() {
-    const name = this.get(TYPE_NAME);
-    return name === undefined ? this.uri : name;
-  };
 
   setAttribute(propType, value) {
 
@@ -194,10 +190,6 @@ export default class GraphNode {
    * @param graphNode
    */
   addAssociatedNode(associationTypeUri, graphNode) {
-
-    if (typeof associationTypeUri !== 'string') {
-      debugger
-    }
 
     const property = this[associationTypeUri];
     if (property === undefined) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ import Factory from '@symb/ComponentFactory';
 window.onload = () => {
   const root = document.getElementById('root');
   const app = Factory.create(App_({key:"root", title:"Hallo Welt"})._App, null, root);
-  console.log('onload executed');
   document.body.style.overflow = 'hidden';
   document.body.onresize = () => {
     app.onResize(window.innerWidth, window.innerHeight);

--- a/src/symb/Component.js
+++ b/src/symb/Component.js
@@ -139,6 +139,7 @@ export default class Component {
       return this.addChild(newChild);
     } else {
       existing.update(netProps, tween);
+      this.dom.appendChild(existing.dom);
     }
     return existing;
   }
@@ -175,12 +176,16 @@ export default class Component {
       result = descriptor
           .filter(Boolean)
           .map(childDescriptor => {
-        const childComponent = this.createChild(`surrogate_key${count++}`, childDescriptor, tween);
-        updatedChildren[childComponent.key] = childComponent;
-      })
+            const childComponent = this.createChild(`surrogate_key${count++}`, childDescriptor, tween);
+            if (childComponent.key) {
+              updatedChildren[childComponent.key] = childComponent;
+            }
+          })
     } else {
       result = this.createChild(`surrogate_key${count}`, descriptor, tween);
-      updatedChildren[result.key] = result;
+      if (result.key) {
+        updatedChildren[result.key] = result;
+      }
     }
     // remove old children that aren't part of children list
     Object.keys(this.childByKey).forEach(key => {

--- a/src/templates/Template.js
+++ b/src/templates/Template.js
@@ -11,6 +11,7 @@ import CardElement from "@/templates/elements/CardElement";
 import CardsElement from "@/templates/elements/CardsElement";
 import TrellisElement from "@/templates/elements/TrellisElement";
 import ChartElement from "@/templates/elements/ChartElement";
+import Filter from "@/graph/Filter";
 
 
 const fillPlaceholders = function fillPlaceholders(element, options, defaultValues) {
@@ -114,6 +115,9 @@ export default class Template {
     const elementClass = elementClassByType[descriptor.type];
     if (!elementClass) {
       console.log(`Unsupported element type ${descriptor.type} ignored`);
+    }
+    if (descriptor.condition && !Filter.fromDescriptor(descriptor.condition).matches(data) ) {
+      return null;
     }
     return elementClass.create({descriptor, data, onClick});
   }

--- a/src/templates/Template.js
+++ b/src/templates/Template.js
@@ -43,6 +43,7 @@ export default class Template {
       type: P.string.isRequired,
       source: P.string,
       color: P.string,
+      cornerRadius: P.number,
       ...sizeType
     }),
     appliesTo: P.oneOfType([P.string,P.array]),

--- a/src/templates/TemplateRegistry.js
+++ b/src/templates/TemplateRegistry.js
@@ -1,7 +1,26 @@
 import Template from './Template';
+import {TYPE_THING} from "@/graph/Cache";
 
-export const ARRANGEMENT_DEFAULT = 'default';
 export const DEFAULT_VIEW_NAME = 'default';
+
+const fallbackTemplate = {
+      "id": "core:thing",
+      "name": "Compact",
+      "appliesTo": "core:thing",
+      "aggregate": false,
+      "size": { "w": 220, "h": 120},
+      "background": { "type": "rect", "w": 220, "h": 120, "cornerRadius": "6px", color: '#D0D0D0'},
+      "clickable": true,
+      "elements": [
+        {
+          "key": "heading-large",
+          "type": "textfield",
+          "x": 15, "y": 35, "w": 190, "h": 50,
+          "attribute": "uri",
+          "style": {"font-weight": "normal", "color": "#202020", "font-size": "18px", "h-align": "center", "v-align": "center"}
+        }
+      ]
+    };
 
 class TemplateRegistry {
 
@@ -10,6 +29,7 @@ class TemplateRegistry {
     this.templatesByContentType = {};
     this.toolsById = {};
     this.toolsByContentType = {};
+    this.registerTemplate(fallbackTemplate);
   }
 
   registerTemplateForType(type, template) {
@@ -63,8 +83,8 @@ class TemplateRegistry {
     const searchName = viewName.toLowerCase();
     const candidates = this.getViewsFor(typeUri, false);
     if (candidates.length === 0)  {
-      console.log(`Error: No template registered for type ${typeUri}`);
-      return null;
+      console.log(`No template registered for type ${typeUri} - falling back to generic`);
+       return this.getTemplate(TYPE_THING);
     }
     let result = candidates.find(template => (template.name || '').toLowerCase() === searchName);
     if (result) return result;

--- a/src/templates/TemplateRegistry.js
+++ b/src/templates/TemplateRegistry.js
@@ -9,7 +9,7 @@ const fallbackTemplate = {
       "appliesTo": "core:thing",
       "aggregate": false,
       "size": { "w": 220, "h": 120},
-      "background": { "type": "rect", "w": 220, "h": 120, "cornerRadius": "6px", color: '#D0D0D0'},
+      "background": { "type": "rect", "w": 220, "h": 120, "cornerRadius": 6, color: '#D0D0D0'},
       "clickable": true,
       "elements": [
         {

--- a/src/templates/elements/BoxElement.js
+++ b/src/templates/elements/BoxElement.js
@@ -1,7 +1,8 @@
+import {pick} from 'lodash';
 import TemplateElement, {StylePropType} from "@/templates/elements/TemplateElement";
 import {Div_} from "@symb/Div";
 import css from "@/components/Card.css";
-import {calcStyle} from "@/components/Generators";
+import {calcStyle, STYLE_ATTRIBUTES} from "@/components/Generators";
 
 export default class BoxElement extends TemplateElement {
 
@@ -12,7 +13,8 @@ export default class BoxElement extends TemplateElement {
   }
 
   static create({descriptor}) {
-    const {key, x, y, w, h, type, ...style} = descriptor;
+    const { key, x, y, w, h } = descriptor;
+    const style = pick(descriptor, STYLE_ATTRIBUTES);
     return Div_({key, className: css.background, size: {width: w, height: h}, spatial: {x, y, scale: 1}, style: calcStyle(style)})._Div
   }
 }

--- a/src/templates/elements/ImageElement.js
+++ b/src/templates/elements/ImageElement.js
@@ -1,8 +1,9 @@
 import P from 'prop-types';
+import {pick} from 'lodash';
 import TemplateElement, {StylePropType} from "@/templates/elements/TemplateElement";
 import {Image_} from "@symb/Image";
 import css from "@/components/Card.css";
-import {calcStyle} from "@/components/Generators";
+import {calcStyle, STYLE_ATTRIBUTES} from "@/components/Generators";
 
 export default class ImageElement extends TemplateElement {
 
@@ -14,7 +15,8 @@ export default class ImageElement extends TemplateElement {
   }
 
   static create({descriptor}) {
-    const {key, x, y, w, h, source, color, type, ...style} = descriptor;
+    const { key, x, y, w, h, source, color } = descriptor;
+    const style = pick(descriptor, STYLE_ATTRIBUTES);
     return Image_({key, source, color, className: css.background, width: w, height: h, spatial: {x, y, scale: 1}, style: calcStyle(style)})._Image
   }
 }

--- a/src/templates/elements/TemplateElement.js
+++ b/src/templates/elements/TemplateElement.js
@@ -24,7 +24,8 @@ export default class TemplateElement {
     x: P.number.isRequired,
     y: P.number.isRequired,
     w: P.number,
-    h: P.number
+    h: P.number,
+    condition: P.objectOf(P.string)
   }
 
   static validate(templateId, descriptor) {


### PR DESCRIPTION
Features:
Allowing dynamic content (handlebars) in condition comparands
Conditional layout elements
Default template to visualize nodes with missing type

Bugfixes:
Bugfix in Cache.resolveAttribute and Cache.resolveProperty
Bugfix in Component (textfields could be hidden behind background on view change)
View options correctly preselected if start template has view options

Other:
cornerRadius of background is now enforced to be numeric
Nodes without types result in console warnings instead of errors
Additional information on missing attributes of dictionary entries
Moved client config from Cache to Config
