### PR TITLE
highlight bugfix and simplification

### DIFF
--- a/dev-backend/testData/templates_tickets.json
+++ b/dev-backend/testData/templates_tickets.json
@@ -418,8 +418,7 @@
         "highlight": {
           "caption": "Highlight",
           "display": "highlight",
-          "inputSelector": {"jira:release": "=1.2"},
-          "dataPath": "jira:is-prerequisite-for[jira:ticket]*",
+          "reference": "graph",
           "selection": [
             {"label": "By Release", "value":  "jira:release"},
             {"label": "By Feature", "value":  "jira:feature"},

--- a/src/App.js
+++ b/src/App.js
@@ -683,17 +683,23 @@ class App extends Component {
     const {currentViewOptions, focusCard, highlightInfo} = this.state;
     const newViewOptions = {...currentViewOptions, [key]: value};
 
-    const option = get(focusCard, ['template', 'descriptor', 'options'])[key];
+    const template = focusCard.template.descriptor;
+    const option = get(template,[ 'options'])[key];
 
     if (option.display === OPTION_HIGHLIGHT) {
       const originalFocus = omit(focusCard, ['highlightCondition']);
       if (value == null) {
         this.setState({highlightInfo: null, highlightMenu: null,  currentViewOptions: newViewOptions, focusCard: originalFocus });
       } else {
-        const {dataPath, inputSelector} = option;
-        const rootNodes = getNodeArray(inputSelector, TYPE_NODES, focusCard.data);
-        const nodes = dataPath ?
-            [...rootNodes, ...traverseWithRecursion(rootNodes, dataPath, LOG_LEVEL_PATHS, '')] :
+        const { reference } = option;
+        const refElement = template.elements.find(el => el.key === reference);
+        if (!refElement) {
+          throw new Error(`Can't find reference element ${reference} in template ${template.id}`);
+        }
+        const {source, path, inputSelector} = refElement;
+        const rootNodes = getNodeArray(inputSelector, source, focusCard.data);
+        const nodes = path ?
+            [...rootNodes, ...traverseWithRecursion(rootNodes, path, LOG_LEVEL_PATHS, '')] :
             rootNodes;
 
         let newHighlightInfo;


### PR DESCRIPTION
highlight option now specifies a layout element as `reference` instead of inputselector and dataPath