### PR TITLE
Fix: Link element can now have missing text

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -119,19 +119,22 @@ class App extends Component {
             });
             let startTemplate;
             let startNode;
+            startTemplate = TemplateRegistry.getTemplate(getConfig('startTemplate'));
+            startNode = createPreprocessedCardNode(startData, null, startTemplate, null);
+            const startCard = this.createFocusCard(startNode, startTemplate, null);
+            const { pinned, pinnedWidth } = this.calcPinnedCardPositions([this.toPinnedCard(startCard, PINNED_ROOT_CARD)], mainWidth, breadCrumbHeight);
+
+            let focusCard;
             if (window.location.href.includes('#')) {
               const decoded = atob(decodeURI(window.location.href.split('#')[1]));
               const {data, template} = JSON.parse(decoded);
               const dataNode = Array.isArray(data) ? data.map(el => Cache.getNodeByUri(el)) : Cache.getNodeByUri(data);
-              startTemplate = TemplateRegistry.getTemplate(template);
-              startNode = createPreprocessedCardNode(dataNode, null, startTemplate, null);
+              const nodeTemplate = TemplateRegistry.getTemplate(template);
+              const node = createPreprocessedCardNode(dataNode, null, startTemplate, null);
+              focusCard = this.createFocusCard(node, nodeTemplate, null)
             } else {
-              startTemplate = TemplateRegistry.getTemplate(getConfig('startTemplate'));
-              startNode = createPreprocessedCardNode(startData, null, startTemplate, null);
+              focusCard = startCard;
             }
-
-            const focusCard = this.createFocusCard(startNode, startTemplate, null);
-            const { pinned, pinnedWidth } = this.calcPinnedCardPositions([this.toPinnedCard(focusCard, PINNED_ROOT_CARD)], mainWidth, breadCrumbHeight);
 
             this.setState({
               focusData: null,

--- a/src/symb/util.js
+++ b/src/symb/util.js
@@ -47,6 +47,7 @@ const findParameters = function findParameters(text) {
 }
 
 export const fillIn = function fillIn(textTemplate, data) {
+  if (!textTemplate || !data) return null;
   const parameters = findParameters(textTemplate);
   let result = textTemplate;
   for (let i = 0; i < parameters.length; i++) {

--- a/src/templates/elements/LinkElement.js
+++ b/src/templates/elements/LinkElement.js
@@ -8,17 +8,18 @@ export default class LinkElement extends TemplateElement {
   static key = 'link';
 
   static propTypes = {...TemplateElement.propTypes,
-    url: P.string.isRequired,
+    url: P.string,
     text: P.string,
     image: P.string,
     modal: P.bool,
+    templateId: P.string,
     modalWidth: P.number,
     modalHeight: P.number,
     style: P.shape(StylePropType)
   }
 
   static create ({descriptor, data}) {
-    const { url, text } = descriptor;
-    return url && Link({...descriptor, text: fillIn(text, data), url: fillIn(url, data)});
+    const { url, templateId, text } = descriptor;
+    return (url || templateId) && Link({...descriptor, text: fillIn(text, data), url: fillIn(url, data)});
   }
 }


### PR DESCRIPTION
When sharing a card, new window will always show start card in addition to template
Feature: Allow `templateId` to be set for all links.