### PR TITLE
Performance Tweaks

### DIFF
--- a/src/graph/Preprocessors.js
+++ b/src/graph/Preprocessors.js
@@ -19,7 +19,7 @@
 // "result": "dependencies"
 
 import Aggregator from "@/Aggregator";
-import Cache, {resolve} from "@/graph/Cache";
+import {resolve} from "@/graph/Cache";
 import Filter from "@/graph/Filter";
 import {deriveAssociations, mapNode, pathAnalysis} from "@/graph/Analysis";
 import {intersectLists, subtractLists, unifyLists} from "@/graph/SetOperations";
@@ -122,7 +122,7 @@ export const preprocess = function preprocess(data, context, preprocessors, logL
         if (!reference) return;
 
         if (Array.isArray(reference)) {
-          result = reference.map(node => mapNode(node, type, Cache.createUri(), mapping, logLevel));
+          result = reference.map(node => mapNode(node, type, `${node.getUniqueKey()}-synth`, mapping, logLevel));
         } else {
           result = mapNode(reference, type, null, mapping, logLevel);
         }

--- a/src/symb/Component.js
+++ b/src/symb/Component.js
@@ -443,20 +443,24 @@ export default class Component {
     }
   }
 
-  clearChildren() {
+  clearChildren(willDelete) {
     if (this.childByKey) {
       Object.keys(this.childByKey).forEach(key => {
         if (this.childByKey[key].destroy) {
-          this.childByKey[key].destroy();
+          this.childByKey[key].destroy(willDelete);
         }
       })
     }
     this.childByKey = {};
   }
 
-  destroy() {
-    this.clearChildren();
-    this.dom.remove();
+  destroy(parentDeletes) {
+
+    this.clearChildren(true);
+    if (!parentDeletes) {
+      console.log(`removing ${this.key}`);
+      this.dom.remove();
+    }
     this.dom = null;
   }
 

--- a/src/templates/elements/ChartElement.js
+++ b/src/templates/elements/ChartElement.js
@@ -44,7 +44,7 @@ const graphPropTypes = {
   minScale: P.number,
   maxScale: P.number,
   nodeAspectRatio: P.number,
-  bounded: P.bool,
+  bounded: P.oneOfType(P.bool, P.string),
   edgeColor: P.string,
   edgeAnnotations: P.arrayOf(P.shape({pointsRight: P.bool, helpTemplate: P.string, toolTip: P.string})),
   removeDisconnected: P.bool


### PR DESCRIPTION
avoid unnecessary DOM removal of child elements, don't use surrogate keys for mapped synthetic nodes (which resulted in unnecessary re-creation of cards)